### PR TITLE
fix: Removing arm64 from tanzu flavour, because auth tool relies on a…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
                     - name: simple
                       platforms: "linux/amd64,linux/arm64"
                     - name: tanzu
-                      platforms: "linux/amd64,linux/arm64"
+                      platforms: "linux/amd64"
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout


### PR DESCRIPTION
…md64 libs

Fixes #26