### PR TITLE
feat: Enables gcloud interactive login

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Authentication requires the following:
 #### Configuration
 
 * Environment GCLOUD_PROJECTID: The id of the Google Cloud project to connect to
-* Environment GCLOUD_USE_SA: Use a service account to log into Google Cloud. Requires GCLOUD_KEYPATH (defaults to false)
+* Environment GCLOUD_USE_SA (Possible values: true, false. Defaults to false): Use a service account to log into Google Cloud. Requires GCLOUD_KEYPATH
 * Environment GCLOUD_KEYPATH: Path inside CloudControl that holds the service account JSON file
 
 ### <a id="simple"></a> simple
@@ -440,6 +440,8 @@ Installs and configures [kubernetes](https://kubernetes.io/docs/reference/kubect
 
 * USE_kubernetes: Enable this feature
 * DEBUG_kubernetes: Debug this feature
+* Environment KUBECTL_DEFAULT_CONTEXT: Sets the default kubectl context after initialisation and when using the
+  k8s-relogin script
 * (azure flavour) Environment AZ_K8S_CLUSTERS: A comma separated list of AKS clusters to manage
   inside *CloudControl* (only for azure flavour).
   Each cluster is a pair of resource group and cluster name, separated by a colon. Optionally, you can specify

--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ Authentication requires the following:
 #### Configuration
 
 * Environment GCLOUD_PROJECTID: The id of the Google Cloud project to connect to
+* Environment GCLOUD_USE_SA: Use a service account to log into Google Cloud. Requires GCLOUD_KEYPATH (defaults to false)
 * Environment GCLOUD_KEYPATH: Path inside CloudControl that holds the service account JSON file
 
 ### <a id="simple"></a> simple

--- a/ccc/client/src/components/Progress.vue
+++ b/ccc/client/src/components/Progress.vue
@@ -14,6 +14,12 @@
           Open Authentication
         </v-btn>
       </v-alert>
+      <v-alert :value="oAuthCode === '' && oAuthUrl !== ''" type="info">
+        CloudControlCenter has detected an authentication request. Click here to open the authentication URL:
+        <v-btn v-on:click="doOAuth">
+          Open Authentication
+        </v-btn>
+      </v-alert>
       <v-alert :value="requiresMFA" type="info">
         CloudControlCenter has detected an MFA code request. Enter the current code of your authenticator:
         <v-form v-on:submit="sendMfa">
@@ -90,7 +96,9 @@ export default class Progress extends Vue {
   }
 
   public async doOAuth() {
-    await navigator.clipboard.writeText(this.oAuthCode);
+    if (this.oAuthCode !== '') {
+      await navigator.clipboard.writeText(this.oAuthCode);
+    }
     window.open(this.oAuthUrl);
   }
 
@@ -143,6 +151,15 @@ export default class Progress extends Vue {
       }
     }
 
+    const googleOauthRegexp = new RegExp(
+        'Your browser has been opened to visit:\n\n\s+(.+)$'
+    );
+    if (googleOauthRegexp.test(output)) {
+      const matches = googleOauthRegexp.exec(output);
+      if (matches) {
+        this.oAuthUrl = matches[1];
+      }
+    }
     // MFA feature. Check for a regexp request, but also check if the MFA was already entered.
     const mfaRegexp = new RegExp('/tmp/mfa');
     const mfaDoneRegExp = new RegExp('\[VALID_CODE\]')

--- a/flavour/gcloud/flavour.yaml
+++ b/flavour/gcloud/flavour.yaml
@@ -11,4 +11,5 @@ description: |
     * Mount a directory that contains the JSON file into the CloudControl container and set GCLOUD_KEYPATH accordingly
 configuration:
     - "Environment GCLOUD_PROJECTID: The id of the Google Cloud project to connect to"
+    - "Environment GCLOUD_USE_SA: Use a service account to log into Google Cloud. Requires GCLOUD_KEYPATH (defaults to false)"
     - "Environment GCLOUD_KEYPATH: Path inside CloudControl that holds the service account JSON file"

--- a/flavour/gcloud/flavour.yaml
+++ b/flavour/gcloud/flavour.yaml
@@ -11,5 +11,5 @@ description: |
     * Mount a directory that contains the JSON file into the CloudControl container and set GCLOUD_KEYPATH accordingly
 configuration:
     - "Environment GCLOUD_PROJECTID: The id of the Google Cloud project to connect to"
-    - "Environment GCLOUD_USE_SA: Use a service account to log into Google Cloud. Requires GCLOUD_KEYPATH (defaults to false)"
+    - "Environment GCLOUD_USE_SA (Possible values: true, false. Defaults to false): Use a service account to log into Google Cloud. Requires GCLOUD_KEYPATH"
     - "Environment GCLOUD_KEYPATH: Path inside CloudControl that holds the service account JSON file"

--- a/flavour/gcloud/flavourinit.sh
+++ b/flavour/gcloud/flavourinit.sh
@@ -2,13 +2,13 @@
 
 . /feature-installer-utils.sh
 
-if [ -z "$GCLOUD_KEYPATH" ]
+if [ "X${GCLOUD_USE_SA:-false}X" == "XtrueX" ] && [ -z "$GCLOUD_KEYPATH" ]
 then
   echo "Please set GCLOUD_KEYPATH environment variable"
   exit 1
 fi
 
-if [ ! -r "$GCLOUD_KEYPATH" ]
+if [ "X${GCLOUD_USE_SA:-false}X" == "XtrueX" ] && [ ! -r "$GCLOUD_KEYPATH" ]
 then
   echo "File ${GCLOUD_KEYPATH} is not readable"
   exit 1
@@ -20,7 +20,12 @@ then
   exit 1
 fi
 
-execHandle "Authenticating service account" gcloud auth activate-service-account --key-file "$GCLOUD_KEYPATH"
+if [ "X${GCLOUD_USE_SA:-false}X" == "XtrueX" ]
+then
+  execHandle "Authenticating service account" gcloud auth activate-service-account --key-file "$GCLOUD_KEYPATH"
+else
+  execHandle "Authenticating service account" gcloud auth login
+fi
 execHandle "Setting project" gcloud config set project "$GCLOUD_PROJECTID"
 
 exit 0


### PR DESCRIPTION
This basically includes a breaking change because old non-interactive-logins need to specify the GCLOUD_USE_SA env now, but the gcloud image wasn't released yet, so I guess we don't need a major change.