### PR TITLE
fix: Set the Azure image version tag

### DIFF
--- a/flavour/azure/Dockerfile.flavour
+++ b/flavour/azure/Dockerfile.flavour
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/azure-cli:latest
+FROM mcr.microsoft.com/azure-cli:2.63.0
 
 RUN apk add sudo bash curl && \
     echo "cloudcontrol ALL=(root)NOPASSWD:/sbin/apk *" > /etc/sudoers.d/cloudcontrol && \


### PR DESCRIPTION
This sets the azure image version tag to the last version that is based on alpine. Newer versions are based on Mariner (which is based on Fedora) so all Features have to be adapted to that.